### PR TITLE
Adjust printing margins for hole punches

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -95,7 +95,8 @@ body{font-size:16px;}
   pre, blockquote { border: 1px solid #999; padding-right: 1em; page-break-inside: avoid; }
   tr, img { page-break-inside: avoid; }
   img { max-width: 100% !important; }
-  @page { margin: 0.5cm; }
+  @page :left { margin: 15mm 20mm 15mm 10mm; }
+  @page :right { margin: 15mm 10mm 15mm 20mm; }
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 }


### PR DESCRIPTION
Uses ISO 838 standards for 20mm. Also works for double sided printing.

source: http://en.wikipedia.org/wiki/Hole_punch
