### PR TITLE
@media print change - makes printed page look like the HTML

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -264,7 +264,10 @@ td {
     content: "";
   }
 
-  pre, code, kbd, samp {
+  pre,
+  code,
+  kbd,
+  samp {
     color: #001;
     font-family: monospace, monospace;
     _font-family: 'courier new', monospace;

--- a/markdown.css
+++ b/markdown.css
@@ -237,38 +237,38 @@ td {
     padding: 1em;
     margin: auto;
     background: #fefefe;
-  } 
+  }
 
-  a, 
+  a,
   a:visited {
     text-decoration: underline;
-  } 
+  }
 
   hr {
     height: 1px;
     border: 0;
     border-bottom: 1px solid black;
-  } 
+  }
 
   a[href]:after {
     content: " (" attr(href) ")";
-  } 
+  }
 
   abbr[title]:after {
     content: " (" attr(title) ")";
-  } 
+  }
 
   .ir a:after, 
   a[href^="javascript:"]:after, 
   a[href^="#"]:after {
     content: "";
-  } 
+  }
 
   pre, code, kbd, samp {
     color: #001;
     font-family: monospace, monospace;
     _font-family: 'courier new', monospace;
-  } 
+  }
 
   pre {
     background: #fdfaf5;
@@ -278,38 +278,40 @@ td {
     word-wrap: break-word;
     padding-left: 0.5em;
     padding-right: 0.5em;
-  } 
+  }
 
   blockquote {
     color: #666666;
     margin: 0;
     padding-left: 3em;
     border-left: 0.5em #EEE solid;
-  } 
+  }
 
   tr, img {
     page-break-inside: avoid;
-  } 
+  }
 
   img {
     max-width: 100% !important;
-  } 
+  }
 
   @page :left {
     margin: 15mm 20mm 15mm 10mm;
-  } 
+  }
 
   @page :right {
     margin: 15mm 10mm 15mm 20mm;
-  } 
+  }
 
-  p, h2, h3 {
+  p,
+  h2,
+  h3 {
     orphans: 3;
     widows: 3;
-  } 
+  }
 
   h3, h2 {
     page-break-after: avoid;
-  } 
+  }
 
 }

--- a/markdown.css
+++ b/markdown.css
@@ -287,7 +287,8 @@ td {
     border-left: 0.5em #EEE solid;
   }
 
-  tr, img {
+  tr,
+  img {
     page-break-inside: avoid;
   }
 
@@ -310,7 +311,8 @@ td {
     widows: 3;
   }
 
-  h3, h2 {
+  h3,
+  h2 {
     page-break-after: avoid;
   }
 

--- a/markdown.css
+++ b/markdown.css
@@ -224,75 +224,92 @@ td {
 
 @media print {
   * {
-    background: transparent !important;
-    color: black !important;
-    filter: none !important;
-    -ms-filter: none !important;
+      filter: none !important;
+      -ms-filter: none !important;
   }
 
   body {
-    font-size: 12pt;
+    color: #444;
     max-width: 100%;
-  }
+    font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
+    font-size: 12pt;
+    line-height:1.5;
+    padding: 1em;
+    margin: auto;
+    background: #fefefe;
+  } 
 
-  a,
+  a, 
   a:visited {
     text-decoration: underline;
-  }
+  } 
 
   hr {
     height: 1px;
     border: 0;
     border-bottom: 1px solid black;
-  }
+  } 
 
   a[href]:after {
     content: " (" attr(href) ")";
-  }
+  } 
 
   abbr[title]:after {
     content: " (" attr(title) ")";
-  }
+  } 
 
-  .ir a:after,
-  a[href^="javascript:"]:after,
+  .ir a:after, 
+  a[href^="javascript:"]:after, 
   a[href^="#"]:after {
     content: "";
-  }
+  } 
 
-  pre,
+  pre, code, kbd, samp {
+    color: #001;
+    font-family: monospace, monospace;
+    _font-family: 'courier new', monospace;
+  } 
+
+  pre {
+    background: #fdfaf5;
+    font-size: 11pt;
+    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  } 
+
   blockquote {
-    border: 1px solid #999;
-    padding-right: 1em;
-    page-break-inside: avoid;
-  }
+    color: #666666;
+    margin: 0;
+    padding-left: 3em;
+    border-left: 0.5em #EEE solid;
+  } 
 
-  tr,
-  img {
+  tr, img {
     page-break-inside: avoid;
-  }
+  } 
 
   img {
     max-width: 100% !important;
-  }
+  } 
 
   @page :left {
     margin: 15mm 20mm 15mm 10mm;
-  }
+  } 
 
   @page :right {
     margin: 15mm 10mm 15mm 20mm;
-  }
+  } 
 
-  p,
-  h2,
-  h3 {
+  p, h2, h3 {
     orphans: 3;
     widows: 3;
-  }
+  } 
 
-  h2,
-  h3 {
+  h3, h2 {
     page-break-after: avoid;
-  }
+  } 
+
 }


### PR DESCRIPTION
Hi!

If you accept pull requests:
I did some small changes to the @media print field in the CSS, so the HTML keeps its look when printed, including code syntax highlighting and block quotes.
If `Print Backgrounds` is selected when printing, the output looks more or less identical to the displayed HTML. :)

Here's how file.html (along with a code block at the bottom) looks when printing: [file.pdf](https://github.com/simonlc/Markdown-CSS/files/2626347/file.pdf)
